### PR TITLE
Fix user update delete

### DIFF
--- a/src/constants/errors.constants.ts
+++ b/src/constants/errors.constants.ts
@@ -3,12 +3,13 @@ export const errorConstant = {
     passwordNotMatching: "Merci de fournir un mot de passe ou le mot de passe et la confirmation du mot de passe ne correspondent pas.",
     requiredPasswordEmailFields: "Les champs email et mot de passe sont requis.",
     userDoesNotExist: "L'utilisateur n'existe pas.",
+    pseudoUnavailable: "Ce pseudo est déjà utilisé",
     serverNotCreated: "Nous n'avons pas pu créer le serveur, veuillez réessayer plus tard.",
-    noUserRights: "Vous n'avez pas les droits pour mettre à jour le serveur.",
+    noUserRightsOnServer: "Vous n'avez pas les droits pour mettre à jour le serveur.",
+    noUserRightsOnUser: "Vous n'avez pas les droits sur cet utilisateur",
     itemNotExisting: "L'item n'existe pas.",
     cannotGetUserChannels : "Nous n'avons pas pu récupérer les channels, veuillez réessayer plus tard.",
     lastAdminCannotLeave : "Vous êtes le dernier admin. Vous devez nommer un autre admin ou supprimer le serveur",
-    pseudoUnavailable: "Ce pseudo est déjà utilisé",
     userNotServerMember: "Vous n'êtes pas membre de ce serveur",
     provideAKeywordToSearchAServer: "Ce champs ne peut pas être vide."
   };

--- a/src/servers/server.service.ts
+++ b/src/servers/server.service.ts
@@ -56,7 +56,7 @@ export class ServerService {
       updated.isCurrentUserMember = true;
       return updated;
     }
-    return new Error(errorConstant.noUserRights);
+    return new Error(errorConstant.noUserRightsOnServer);
   }
 
   async remove(id: string, userId: string) {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -192,6 +192,4 @@ export class UsersController {
       throw new BadRequestException(errorConstant.errorOccured);
     }
   }
-
-  
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -143,11 +143,11 @@ export class UsersController {
   @Put(':id')
   @ApiOkResponse({ type: UserDto })
   @ApiBadRequestResponse({type: BadRequestException})
-  async update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+  async update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto, @Request() req) {
     const result = new OperationResult<UserDto | null>();
     result.isSucceed = false;
     try {
-      const updatedUser = await this.usersService.update(id, updateUserDto);
+      const updatedUser = await this.usersService.update(req.user.id, id, updateUserDto);
       if(updatedUser) {
         result.isSucceed = true;
         result.result = this.mapper.map(updatedUser, UserEntity, UserDto);
@@ -159,6 +159,9 @@ export class UsersController {
         Logger.log(error);
         if(error instanceof PrismaClientKnownRequestError  && error.message.includes("Unique constraint failed on the fields: (`pseudo`)")) {
           throw new BadRequestException(errorConstant.pseudoUnavailable);
+        }
+        if(error instanceof BadRequestException) {
+          throw error;
         }
         throw new BadRequestException(errorConstant.errorOccured);
     }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -176,16 +176,19 @@ export class UsersController {
   @Delete(':id')
   @ApiOkResponse({ type: Boolean })
   @ApiBadRequestResponse({type: BadRequestException})
-  async remove(@Param('id') id: string) {
+  async remove(@Param('id') id: string, @Request() req) {
     const response = new OperationResult<boolean>();
     response.isSucceed = false;
     try {
-      await this.usersService.remove(id);
+      await this.usersService.remove(req.user.id, id);
       response.isSucceed = true;
       response.result = true;
       return response;
     } catch (error) {
       Logger.log(error);
+      if(error instanceof BadRequestException) {
+        throw error;
+      }
       throw new BadRequestException(errorConstant.errorOccured);
     }
   }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { SigninUserDto } from '../dtos/users/signin-user-dto';
 import { UpdateUserDto } from '../dtos/users/update-user.dto';
 import { PrismaService } from '../prisma/prisma.service';
@@ -37,7 +37,11 @@ export class UsersService {
     return this.prisma.user.findFirst({ where: {email : signinUserDto.email }, include: {prefs: {select: {colorScheme: true}}}});
   }
 
-  async update(id: string, updateUserDto: UpdateUserDto) {
+  async update(reqUserId: string, id: string, updateUserDto: UpdateUserDto) {
+    //control user rights
+    if(reqUserId !== id) {
+      throw new BadRequestException(errorConstant.noUserRightsOnUser);
+    }
     if(updateUserDto.password){
       const user = await this.findOne(id);
       if(user && updateUserDto.oldPassword){

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -61,7 +61,11 @@ export class UsersService {
     });
   }
 
-  remove(id: string) {
+  remove(reqUserId, id: string) {
+    //control user rights
+    if(reqUserId !== id) {
+      throw new BadRequestException(errorConstant.noUserRightsOnUser);
+    }
     return this.prisma.user.delete({ where: { id } });
   }
 


### PR DESCRIPTION
Fixed a security issue.
Users where able to update or delete other users.
This feature now includes a control over the id query param that must equals req.user.id.
This control my be updated in the future, maybe some 'superusers' will be able to update or delete other users.